### PR TITLE
refactor backend storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# sqlite
+/data.db
+
+# user images
+/images/*
+!/images/.gitkeep

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,18 +3,17 @@
 ## SQLite Setup
 - `lib/db.ts` initializes a SQLite database (`data.db`) using `better-sqlite3`.
 - Tables:
-  - **spreadsheets** – stores meta information (`customerName`, `orderId`, `contactPerson`, `notes`).
-  - **cells** – stores individual cell values with `row`, `col`, `mode` (`base`, `quotation`, `production`), `type` (`text` or `image`), and `content`.
-- On first run the database is seeded with sample data.
+  - **tasks** – stores meta information (`customerName`, `orderId`, `contactPerson`, `notes`).
+  - **cells** – stores individual cell values with `task_id`, `row`, `col`, `type` (`text` or `image`), and `content`.
 
 ## API Routes
-- `app/api/spreadsheet/route.ts` provides a Node.js runtime API.
-  - `GET` returns spreadsheet meta data and cell matrices for each mode.
-  - `POST` updates cells or meta data. Image data is decoded, saved to `/public/images`, and the stored path is written back to the database.
+- `app/api/tasks/[id]/route.ts` provides a Node.js runtime API.
+  - `GET` returns task meta data and cell matrices.
+  - `POST` updates cells or meta data. Image data is decoded, saved to `/images`, and the stored path is written back to the database.
 
 ## Frontend
-- `app/preview/page.tsx` loads spreadsheet data from the API and renders the grid.
+- `app/preview/[id]/page.tsx` loads task data from the API and renders the grid.
 - Cell edits invoke the API to persist changes. When an image is pasted, it is uploaded and the returned `/images/...` path is displayed in the cell.
 
 ## Images
-- All pasted images are stored in `public/images`. The database keeps only the relative path (e.g., `/images/<file>`), ensuring consistent rendering across the app.
+- All pasted images are stored in `images/`. The database keeps only the relative path (e.g., `/images/<file>`), ensuring consistent rendering across the app.

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -12,11 +12,14 @@ function cellId(col: number, row: number) {
   return `${String.fromCharCode(65 + col)}${row + 1}`;
 }
 
-export async function GET() {
-  const spreadsheetId = 1;
-  const meta = db.prepare('SELECT customerName, orderId, contactPerson, notes FROM spreadsheets WHERE id=?').get(spreadsheetId);
-  const cells = db.prepare('SELECT row, col, mode, type, content FROM cells WHERE spreadsheet_id=?').all(spreadsheetId);
-  const rows = cells.length ? Math.max(...cells.map(c => c.row)) + 1 : 0;
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const taskId = params.id;
+  const meta = db.prepare('SELECT customerName, orderId, contactPerson, notes FROM tasks WHERE id=?').get(taskId) || {};
+  const cells = db.prepare('SELECT row, col, type, content FROM cells WHERE task_id=?').all(taskId);
+  const rows = cells.length ? Math.max(...cells.map((c: any) => c.row)) + 1 : 0;
 
   const baseData: any[] = [];
   const quotationExtraData: any[] = [];
@@ -24,38 +27,39 @@ export async function GET() {
 
   for (let r = 0; r < rows; r++) {
     baseData[r] = [];
+    quotationExtraData[r] = [];
+    productionExtraData[r] = [];
     for (let c = 0; c < baseColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'base' && cell.row === r && cell.col === c);
+      const cell = cells.find((cell: any) => cell.row === r && cell.col === c);
       baseData[r][c] = { id: cellId(c, r), type: cell?.type || 'text', content: cell?.content || '' };
     }
-    quotationExtraData[r] = [];
     for (let c = 0; c < extraColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'quotation' && cell.row === r && cell.col === c);
-      quotationExtraData[r][c] = { id: cellId(baseColCount + c, r), type: cell?.type || 'text', content: cell?.content || '' };
-    }
-    productionExtraData[r] = [];
-    for (let c = 0; c < extraColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'production' && cell.row === r && cell.col === c);
-      productionExtraData[r][c] = { id: cellId(baseColCount + c, r), type: cell?.type || 'text', content: cell?.content || '' };
+      const qCell = cells.find((cell: any) => cell.row === r && cell.col === baseColCount + c);
+      quotationExtraData[r][c] = { id: cellId(baseColCount + c, r), type: qCell?.type || 'text', content: qCell?.content || '' };
+      const pCell = cells.find((cell: any) => cell.row === r && cell.col === baseColCount + extraColCount + c);
+      productionExtraData[r][c] = { id: cellId(baseColCount + extraColCount + c, r), type: pCell?.type || 'text', content: pCell?.content || '' };
     }
   }
 
   return NextResponse.json({ meta, baseData, quotationExtraData, productionExtraData });
 }
 
-export async function POST(request: Request) {
-  const body = await request.json();
-  const spreadsheetId = 1;
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const taskId = params.id;
+  const body = await req.json();
 
   if (body.meta) {
     const keys = Object.keys(body.meta);
     const values = keys.map((k) => body.meta[k]);
     const sets = keys.map((k) => `${k}=?`).join(', ');
-    db.prepare(`UPDATE spreadsheets SET ${sets} WHERE id=?`).run(...values, spreadsheetId);
+    db.prepare(`UPDATE tasks SET ${sets} WHERE id=?`).run(...values, taskId);
     return NextResponse.json({ ok: true });
   }
 
-  const { rowIndex, colIndex, content, type, mode } = body;
+  const { rowIndex, colIndex, content, type } = body;
   let storedContent = content;
 
   if (type === 'image' && content.startsWith('data:')) {
@@ -63,7 +67,7 @@ export async function POST(request: Request) {
     if (matches) {
       const ext = matches[1].split('/')[1];
       const buffer = Buffer.from(matches[2], 'base64');
-      const dir = path.join(process.cwd(), 'public', 'images');
+      const dir = path.join(process.cwd(), 'images');
       fs.mkdirSync(dir, { recursive: true });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
       const filePath = path.join(dir, filename);
@@ -72,14 +76,20 @@ export async function POST(request: Request) {
     }
   }
 
-  const existing = db.prepare('SELECT id FROM cells WHERE spreadsheet_id=? AND row=? AND col=? AND mode=?')
-    .get(spreadsheetId, rowIndex, colIndex, mode);
+  const existing = db
+    .prepare('SELECT id FROM cells WHERE task_id=? AND row=? AND col=?')
+    .get(taskId, rowIndex, colIndex);
 
   if (existing) {
     db.prepare('UPDATE cells SET type=?, content=? WHERE id=?').run(type, storedContent, existing.id);
   } else {
-    db.prepare('INSERT INTO cells (spreadsheet_id,row,col,mode,type,content) VALUES (?,?,?,?,?,?)')
-      .run(spreadsheetId, rowIndex, colIndex, mode, type, storedContent);
+    db.prepare('INSERT INTO cells (task_id,row,col,type,content) VALUES (?,?,?,?,?)').run(
+      taskId,
+      rowIndex,
+      colIndex,
+      type,
+      storedContent
+    );
   }
 
   return NextResponse.json({ content: storedContent, type });

--- a/app/images/[filename]/route.ts
+++ b/app/images/[filename]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { filename: string } }
+) {
+  const filePath = path.join(process.cwd(), 'images', params.filename);
+  if (!fs.existsSync(filePath)) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+  const file = fs.readFileSync(filePath);
+  const ext = path.extname(filePath).slice(1);
+  const contentType = `image/${ext === 'jpg' ? 'jpeg' : ext}`;
+  return new NextResponse(file, {
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'private, max-age=31536000'
+    }
+  });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,8 +5,8 @@ const dbFile = path.join(process.cwd(), 'data.db');
 const db = new Database(dbFile);
 
 db.exec(`
-  CREATE TABLE IF NOT EXISTS spreadsheets (
-    id INTEGER PRIMARY KEY,
+  CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
     customerName TEXT,
     orderId TEXT,
     contactPerson TEXT,
@@ -14,54 +14,14 @@ db.exec(`
   );
 
   CREATE TABLE IF NOT EXISTS cells (
-    id INTEGER PRIMARY KEY,
-    spreadsheet_id INTEGER,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT,
     row INTEGER,
     col INTEGER,
-    mode TEXT,
     type TEXT,
     content TEXT,
-    FOREIGN KEY(spreadsheet_id) REFERENCES spreadsheets(id)
+    FOREIGN KEY(task_id) REFERENCES tasks(id)
   );
 `);
-
-const countRow = db.prepare('SELECT COUNT(*) as count FROM spreadsheets').get();
-if (countRow.count === 0) {
-  const info = db.prepare(`INSERT INTO spreadsheets (customerName, orderId, contactPerson, notes)
-    VALUES (?, ?, ?, ?)`)
-    .run('Apple Inc.', `QUO-${new Date().getFullYear()}-0815`, 'Tim Cook', 'Urgent project for visionOS.');
-  const spreadsheetId = info.lastInsertRowid as number;
-
-  const baseSeed = [
-    ['', 'M3 Pro 笔记本电脑', '铝合金', '100', '深空黑', '加急订单'],
-    ['', '无线充电底座', 'PC+ABS', '500', '类肤质喷涂', '需定制Logo'],
-    ['', '精密仪器外壳', '不锈钢 304', '250', '镜面抛光', ''],
-  ];
-
-  const quotationSeed = [
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-  ];
-
-  const productionSeed = [
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-  ];
-
-  const insert = db.prepare('INSERT INTO cells (spreadsheet_id,row,col,mode,type,content) VALUES (?,?,?,?,?,?)');
-  for (let r = 0; r < baseSeed.length; r++) {
-    for (let c = 0; c < baseSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'base', 'text', baseSeed[r][c]);
-    }
-    for (let c = 0; c < quotationSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'quotation', 'text', quotationSeed[r][c]);
-    }
-    for (let c = 0; c < productionSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'production', 'text', productionSeed[r][c]);
-    }
-  }
-}
 
 export default db;


### PR DESCRIPTION
## Summary
- support multiple tasks by storing task meta and cell data without per-mode columns
- dynamically serve uploaded images from root `/images` instead of `public`
- generalize preview to `/preview/[id]` and backend API to `/api/tasks/[id]`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive setup prompt)*


------
https://chatgpt.com/codex/tasks/task_e_6893435adf60832faff136fb9149349b