### PR TITLE
Revamp backend for generic tasks and dynamic images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 
+# runtime data
+/data.db
+/images
+
 # vercel
 .vercel
 

--- a/app/api/images/[filename]/route.ts
+++ b/app/api/images/[filename]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import fs from 'fs';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { filename: string } }
+) {
+  const filePath = path.join(process.cwd(), 'images', params.filename);
+  if (!fs.existsSync(filePath)) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+  const file = await fs.promises.readFile(filePath);
+  const ext = path.extname(params.filename).slice(1);
+  const type = `image/${ext === 'jpg' ? 'jpeg' : ext}`;
+  return new NextResponse(file, {
+    headers: {
+      'Content-Type': type,
+    },
+  });
+}

--- a/app/api/spreadsheet/route.ts
+++ b/app/api/spreadsheet/route.ts
@@ -3,59 +3,44 @@ import path from 'path';
 import fs from 'fs';
 import db from '@/lib/db';
 
-const baseColCount = 6;
-const extraColCount = 2;
-
 export const runtime = 'nodejs';
 
-function cellId(col: number, row: number) {
-  return `${String.fromCharCode(65 + col)}${row + 1}`;
-}
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const taskId = Number(searchParams.get('taskId')) || 1;
 
-export async function GET() {
-  const spreadsheetId = 1;
-  const meta = db.prepare('SELECT customerName, orderId, contactPerson, notes FROM spreadsheets WHERE id=?').get(spreadsheetId);
-  const cells = db.prepare('SELECT row, col, mode, type, content FROM cells WHERE spreadsheet_id=?').all(spreadsheetId);
-  const rows = cells.length ? Math.max(...cells.map(c => c.row)) + 1 : 0;
-
-  const baseData: any[] = [];
-  const quotationExtraData: any[] = [];
-  const productionExtraData: any[] = [];
-
-  for (let r = 0; r < rows; r++) {
-    baseData[r] = [];
-    for (let c = 0; c < baseColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'base' && cell.row === r && cell.col === c);
-      baseData[r][c] = { id: cellId(c, r), type: cell?.type || 'text', content: cell?.content || '' };
-    }
-    quotationExtraData[r] = [];
-    for (let c = 0; c < extraColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'quotation' && cell.row === r && cell.col === c);
-      quotationExtraData[r][c] = { id: cellId(baseColCount + c, r), type: cell?.type || 'text', content: cell?.content || '' };
-    }
-    productionExtraData[r] = [];
-    for (let c = 0; c < extraColCount; c++) {
-      const cell = cells.find((cell: any) => cell.mode === 'production' && cell.row === r && cell.col === c);
-      productionExtraData[r][c] = { id: cellId(baseColCount + c, r), type: cell?.type || 'text', content: cell?.content || '' };
-    }
+  let task = db.prepare('SELECT meta FROM tasks WHERE id=?').get(taskId);
+  if (!task) {
+    db.prepare('INSERT INTO tasks (id, meta) VALUES (?, ?)').run(taskId, '{}');
+    task = { meta: '{}' };
   }
 
-  return NextResponse.json({ meta, baseData, quotationExtraData, productionExtraData });
+  const cells = db
+    .prepare('SELECT row, col, type, content FROM cells WHERE task_id=?')
+    .all(taskId);
+
+  return NextResponse.json({ meta: JSON.parse(task.meta || '{}'), cells });
 }
 
 export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const taskId = Number(searchParams.get('taskId')) || 1;
   const body = await request.json();
-  const spreadsheetId = 1;
+
+  let task = db.prepare('SELECT id, meta FROM tasks WHERE id=?').get(taskId);
+  if (!task) {
+    db.prepare('INSERT INTO tasks (id, meta) VALUES (?, ?)').run(taskId, '{}');
+    task = { id: taskId, meta: '{}' };
+  }
 
   if (body.meta) {
-    const keys = Object.keys(body.meta);
-    const values = keys.map((k) => body.meta[k]);
-    const sets = keys.map((k) => `${k}=?`).join(', ');
-    db.prepare(`UPDATE spreadsheets SET ${sets} WHERE id=?`).run(...values, spreadsheetId);
+    const current = JSON.parse(task.meta || '{}');
+    const updated = { ...current, ...body.meta };
+    db.prepare('UPDATE tasks SET meta=? WHERE id=?').run(JSON.stringify(updated), taskId);
     return NextResponse.json({ ok: true });
   }
 
-  const { rowIndex, colIndex, content, type, mode } = body;
+  const { rowIndex, colIndex, content, type } = body;
   let storedContent = content;
 
   if (type === 'image' && content.startsWith('data:')) {
@@ -63,23 +48,24 @@ export async function POST(request: Request) {
     if (matches) {
       const ext = matches[1].split('/')[1];
       const buffer = Buffer.from(matches[2], 'base64');
-      const dir = path.join(process.cwd(), 'public', 'images');
+      const dir = path.join(process.cwd(), 'images');
       fs.mkdirSync(dir, { recursive: true });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
       const filePath = path.join(dir, filename);
       fs.writeFileSync(filePath, buffer);
-      storedContent = `/images/${filename}`;
+      storedContent = `/api/images/${filename}`;
     }
   }
 
-  const existing = db.prepare('SELECT id FROM cells WHERE spreadsheet_id=? AND row=? AND col=? AND mode=?')
-    .get(spreadsheetId, rowIndex, colIndex, mode);
+  const existing = db
+    .prepare('SELECT id FROM cells WHERE task_id=? AND row=? AND col=?')
+    .get(taskId, rowIndex, colIndex);
 
   if (existing) {
     db.prepare('UPDATE cells SET type=?, content=? WHERE id=?').run(type, storedContent, existing.id);
   } else {
-    db.prepare('INSERT INTO cells (spreadsheet_id,row,col,mode,type,content) VALUES (?,?,?,?,?,?)')
-      .run(spreadsheetId, rowIndex, colIndex, mode, type, storedContent);
+    db.prepare('INSERT INTO cells (task_id,row,col,type,content) VALUES (?,?,?,?,?)')
+      .run(taskId, rowIndex, colIndex, type, storedContent);
   }
 
   return NextResponse.json({ content: storedContent, type });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import db from '@/lib/db';
+
+export async function GET() {
+  const rows = db.prepare('SELECT id, meta FROM tasks').all();
+  const tasks = rows.map((r: any) => ({ id: r.id, meta: JSON.parse(r.meta || '{}') }));
+  return NextResponse.json({ tasks });
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const meta = JSON.stringify(body.meta || {});
+  const info = db.prepare('INSERT INTO tasks (meta) VALUES (?)').run(meta);
+  return NextResponse.json({ id: info.lastInsertRowid });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,63 +5,20 @@ const dbFile = path.join(process.cwd(), 'data.db');
 const db = new Database(dbFile);
 
 db.exec(`
-  CREATE TABLE IF NOT EXISTS spreadsheets (
+  CREATE TABLE IF NOT EXISTS tasks (
     id INTEGER PRIMARY KEY,
-    customerName TEXT,
-    orderId TEXT,
-    contactPerson TEXT,
-    notes TEXT
+    meta TEXT
   );
 
   CREATE TABLE IF NOT EXISTS cells (
     id INTEGER PRIMARY KEY,
-    spreadsheet_id INTEGER,
+    task_id INTEGER,
     row INTEGER,
     col INTEGER,
-    mode TEXT,
     type TEXT,
     content TEXT,
-    FOREIGN KEY(spreadsheet_id) REFERENCES spreadsheets(id)
+    FOREIGN KEY(task_id) REFERENCES tasks(id)
   );
 `);
-
-const countRow = db.prepare('SELECT COUNT(*) as count FROM spreadsheets').get();
-if (countRow.count === 0) {
-  const info = db.prepare(`INSERT INTO spreadsheets (customerName, orderId, contactPerson, notes)
-    VALUES (?, ?, ?, ?)`)
-    .run('Apple Inc.', `QUO-${new Date().getFullYear()}-0815`, 'Tim Cook', 'Urgent project for visionOS.');
-  const spreadsheetId = info.lastInsertRowid as number;
-
-  const baseSeed = [
-    ['', 'M3 Pro 笔记本电脑', '铝合金', '100', '深空黑', '加急订单'],
-    ['', '无线充电底座', 'PC+ABS', '500', '类肤质喷涂', '需定制Logo'],
-    ['', '精密仪器外壳', '不锈钢 304', '250', '镜面抛光', ''],
-  ];
-
-  const quotationSeed = [
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-    [`${(Math.random() * 500 + 100).toFixed(2)}`, ''],
-  ];
-
-  const productionSeed = [
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-    ['CNC 5轴', '公差 +/- 0.02mm'],
-  ];
-
-  const insert = db.prepare('INSERT INTO cells (spreadsheet_id,row,col,mode,type,content) VALUES (?,?,?,?,?,?)');
-  for (let r = 0; r < baseSeed.length; r++) {
-    for (let c = 0; c < baseSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'base', 'text', baseSeed[r][c]);
-    }
-    for (let c = 0; c < quotationSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'quotation', 'text', quotationSeed[r][c]);
-    }
-    for (let c = 0; c < productionSeed[r].length; c++) {
-      insert.run(spreadsheetId, r, c, 'production', 'text', productionSeed[r][c]);
-    }
-  }
-}
 
 export default db;


### PR DESCRIPTION
## Summary
- Store all spreadsheet content in generic `tasks` and `cells` tables and drop per‑mode storage
- Save pasted images under `/images` and expose them through a dedicated API route
- Make the preview page task‑aware and add a simple tasks API for board integration

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6893435adf60832faff136fb9149349b