### PR TITLE
feat: add pricing columns to outsourcing view

### DIFF
--- a/app/print/[mode]/page.tsx
+++ b/app/print/[mode]/page.tsx
@@ -105,7 +105,25 @@ export default function PrintPage({ params }: { params: { mode: Mode } }) {
             });
             break;
           }
-          case "outsourcing":
+          case "outsourcing": {
+            const headersBefore = baseHeadersWithoutOutsourcing.slice(0, 4);
+            const headersAfter = baseHeadersWithoutOutsourcing.slice(4);
+            currentHeaders = [...headersBefore, ...quotationHeaders, ...headersAfter, outsourcingHeader];
+            displayData = base.map((row, i) => {
+              const outsourcingCell = row[outsourcingColIndex];
+              const basePart1 = row.slice(0, 4);
+              const basePart2 = row.slice(4, outsourcingColIndex);
+              const quantity = parseFloat(row[3].content) || 0;
+              const unitPrice = parseFloat(quotation[i][0].content) || 0;
+              const totalPrice = quantity * unitPrice;
+              const calculated = [
+                { ...quotation[i][0] },
+                { ...quotation[i][1], content: totalPrice > 0 ? totalPrice.toFixed(2) : "" },
+              ];
+              return [...basePart1, ...calculated, ...basePart2, outsourcingCell];
+            });
+            break;
+          }
           case "shipping":
           default: {
             currentHeaders = [...baseHeadersWithoutOutsourcing, outsourcingHeader];

--- a/components/Spreadsheet.tsx
+++ b/components/Spreadsheet.tsx
@@ -244,6 +244,21 @@ const Spreadsheet: FC<{ taskId: string }> = ({ taskId }) => {
           }),
         };
       case 'outsourcing':
+        return {
+          currentHeaders: [...baseHeadersWithoutOutsourcing, ...quotationHeaders, outsourcingHeader],
+          displayData: baseData.map((row, i) => {
+            const outsourcingCell = row[outsourcingColIndex];
+            const baseWithoutOutsourcing = row.slice(0, outsourcingColIndex);
+            const quantity = parseFloat(row[3].content) || 0;
+            const unitPrice = parseFloat(quotationExtraData[i][0].content) || 0;
+            const totalPrice = quantity * unitPrice;
+            const calculatedRow = [
+              { ...quotationExtraData[i][0] },
+              { ...quotationExtraData[i][1], content: totalPrice > 0 ? totalPrice.toFixed(2) : '' },
+            ];
+            return [...baseWithoutOutsourcing, ...calculatedRow, outsourcingCell];
+          }),
+        };
       case 'shipping':
       default:
         return {


### PR DESCRIPTION
## Summary
- display 单价 and 总价 columns for 采购单 view with calculated totals
- include new pricing columns in outsourcing print layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68944cfe3870832fa60632b4694ddbe4