### PR TITLE
feat: add outsourcing meta section and scrolling

### DIFF
--- a/app/print/[mode]/page.tsx
+++ b/app/print/[mode]/page.tsx
@@ -10,12 +10,14 @@ import shippingStyles from "../shipping.module.css";
 type Mode = "quotation" | "outsourcing" | "production" | "shipping";
 
 type Cell = { type: string; content: string };
-type MetaData = { 
-  customerName?: string; 
-  contactPerson?: string; 
-  orderId?: string; 
+type MetaData = {
+  customerName?: string;
+  contactPerson?: string;
+  orderId?: string;
   notes?: string;
   supplier?: string;
+  supplierContact?: string;
+  purchaseNotes?: string;
   sendOutTime?: string;
 };
 
@@ -214,7 +216,7 @@ export default function PrintPage({ params }: { params: { mode: Mode } }) {
                     <span>采购单号：{metaData.orderId || '________________'}</span>
                     <span>寄出时间：{metaData.sendOutTime ? new Date(metaData.sendOutTime).toLocaleDateString('zh-CN') : '________________'}</span>
                     <span>供应商：{metaData.supplier || '________________'}</span>
-                    <span>联系人：{metaData.contactPerson || '________________'}</span>
+                    <span>联系人：{metaData.supplierContact || '________________'}</span>
                     <span className={styles.fullWidth}>收件地址：杭州市富阳区</span>
                     <span className={styles.fullWidth}>收件人：王雪梅</span>
                 </div>
@@ -234,6 +236,7 @@ export default function PrintPage({ params }: { params: { mode: Mode } }) {
                 </table>
             </main>
             <footer className={styles.footer}>
+                <div className={styles.notes}>采购备注：{metaData.purchaseNotes || '无'}</div>
                 <div className={styles.summary}>
                     <div className={styles.total}>
                         <span>合计 (RMB):</span>

--- a/app/print/outsourcing.module.css
+++ b/app/print/outsourcing.module.css
@@ -111,6 +111,12 @@
   font-size: 13px;
 }
 
+.notes {
+  color: #636366;
+  margin-bottom: 20px;
+  min-height: 40px;
+}
+
 .summary {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- show base customer fields plus supplier-specific inputs on 采购单 spreadsheet
- allow vertical scrolling on spreadsheet view
- display supplier contact and purchase notes on 采购单 printout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68945779e8d8832fb64bc4a4b7b2f6ab